### PR TITLE
Bump Makie / GraphMakie compat; revert Julia 1.11 CI pin

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - '1.11'
+          - '1'
         os:
           - ubuntu-latest
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMakie"
 uuid = "72ca75eb-df6f-4d6b-80c5-d5eab17be3f9"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -12,10 +12,10 @@ NetworkLayout = "46757867-2c16-5918-afeb-47bfcb05e46a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-Colors = "0.12.8"
-GraphMakie = "0.3.0, 0.4, 0.5"
-Graphs = "1.4.1"
-ITensorVisualizationBase = "0.1.5"
-NetworkLayout = "0.4.3"
-Reexport = "1.2.2"
-julia = "1.6"
+Colors = "0.13"
+GraphMakie = "0.6"
+Graphs = "1"
+ITensorVisualizationBase = "0.1"
+NetworkLayout = "0.4.9"
+Reexport = "1"
+julia = "1.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,5 +9,3 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[compat]
-ITensors = "0.6.8"


### PR DESCRIPTION
## Summary

Drops old compat bounds that were forcing Pkg to resolve Makie 0.21.x (which uses `Core.TypeName.mt` — removed in Julia 1.12, see [MakieOrg/Makie.jl#5496](https://github.com/MakieOrg/Makie.jl/issues/5496)):

- `Colors`: `0.12.8` → `0.13`
- `GraphMakie`: `0.3.0, 0.4, 0.5` → `0.6`
- `Graphs`: `1.4.1` → `1`
- `ITensorVisualizationBase`: `0.1.5` → `0.1`
- `NetworkLayout`: `0.4.3` → `0.4.9` (required by GraphMakie 0.6)
- `Reexport`: `1.2.2` → `1`
- `julia`: `1.6` → `1.10` (match ecosystem baseline)

Now resolves to Makie 0.24.9 / GraphMakie 0.6.3. Package loads and the visualization code runs cleanly on Julia 1.12 (verified locally via `Pkg.test` with `JULIA_REFERENCETESTS_UPDATE=true`, same as CI's flow).

Also:
- Reverts the Phase 0 Julia 1.11 CI pin back to `'1'` now that the root cause (old Makie pinning Julia 1.11) is fixed.
- Drops the stale `test/Project.toml` `ITensors = "0.6.8"` compat entry; transitive ITensors is pulled in via ITensorVisualizationBase at the version it requires.

Version bump `0.1.4` → `0.2.0` (breaking compat drop on a pre-1.0 package).

## Test plan

- [ ] CI passes on Julia lts and 1 (now meaning 1.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)